### PR TITLE
Fix printf()'s excessive newline

### DIFF
--- a/lib/Format.js
+++ b/lib/Format.js
@@ -34,12 +34,19 @@ function stringify(o, opt) {
     }
   }
   var ppf = new Formatter(opt);
-  return ppf.sprintf("@[<hv>%a@]@.", str, o);
+  return ppf.printf("@[<hv>%a@]@.", str, o);
 }
 
-function defFormatterFun(n) {
+function stdFormatterFun(n) {
   return function () {
-    var ppf = Format.defaultFormatter;
+    var ppf = Format.stdFormatter;
+    return ppf[n].apply(ppf, arguments);
+  };
+}
+
+function strFormatterFun(n) {
+  return function () {
+    var ppf = Format.strFormatter;
     return ppf[n].apply(ppf, arguments);
   };
 }
@@ -47,18 +54,28 @@ function defFormatterFun(n) {
 var Format = {
   Formatter: Formatter,
 
-  defaultFormatter: new Formatter({
+  stdFormatter: new Formatter({
+    margin: (process.stdout && process.stdout.columns) || 78,
+    maxIndent: 0,
+    onFinish: function (s) { console.log(s); },
+  }),
+
+  strFormatter: new Formatter({
     margin: (process.stdout && process.stdout.columns) || 78,
     maxIndent: 0,
   }),
 
-  setMargin: defFormatterFun("setMargin"),
-  getMargin: defFormatterFun("getMargin"),
-  setMaxIndent: defFormatterFun("setMaxIndent"),
-  getMaxIndent: defFormatterFun("getMaxIndent"),
+  setMargin: stdFormatterFun("setMargin"),
+  getMargin: stdFormatterFun("getMargin"),
+  setMaxIndent: stdFormatterFun("setMaxIndent"),
+  getMaxIndent: stdFormatterFun("getMaxIndent"),
+  printf: stdFormatterFun("printf"),
 
-  sprintf: defFormatterFun("sprintf"),
-  printf: defFormatterFun("printf"),
+  setStrMargin: strFormatterFun("setMargin"),
+  getStrMargin: strFormatterFun("getMargin"),
+  setStrMaxIndent: strFormatterFun("setMaxIndent"),
+  getStrMaxIndent: strFormatterFun("getMaxIndent"),
+  sprintf: strFormatterFun("printf"),
 
   stringify: stringify,
 };

--- a/lib/Format.js
+++ b/lib/Format.js
@@ -34,7 +34,7 @@ function stringify(o, opt) {
     }
   }
   var ppf = new Formatter(opt);
-  return ppf.printf("@[<hv>%a@]@.", str, o);
+  return ppf.printf("@[<hv>%a@]@?", str, o);
 }
 
 function stdFormatterFun(n) {
@@ -65,20 +65,20 @@ var Format = {
     maxIndent: 0,
   }),
 
+  printf: stdFormatterFun("printf"),
+  sprintf: strFormatterFun("printf"),
+
   setMargin: stdFormatterFun("setMargin"),
   getMargin: stdFormatterFun("getMargin"),
   setMaxIndent: stdFormatterFun("setMaxIndent"),
   getMaxIndent: stdFormatterFun("getMaxIndent"),
-  printf: stdFormatterFun("printf"),
 
   setStrMargin: strFormatterFun("setMargin"),
   getStrMargin: strFormatterFun("getMargin"),
   setStrMaxIndent: strFormatterFun("setMaxIndent"),
   getStrMaxIndent: strFormatterFun("getMaxIndent"),
-  sprintf: strFormatterFun("printf"),
 
   stringify: stringify,
 };
 
 module.exports = Format;
-

--- a/lib/Formatter.js
+++ b/lib/Formatter.js
@@ -237,7 +237,7 @@ proto.printf_a_ = function (format, args) {
         this.closeBox();
         break;
       case "@.":
-        this.printFlush();
+        this.printNewline();
         break;
       case "@ ":
         this.printSpace();

--- a/lib/Formatter.js
+++ b/lib/Formatter.js
@@ -14,12 +14,13 @@ var numberToString = require("./numberToString");
 function Formatter(opt) {
   opt || (opt = {});
 
-  this.printer_ = Printer.makeStringPrinter(opt);
-
+  this.printer_ = new Printer(opt);
   this.margin_ = opt.margin || 80;
   this.maxIndent_ = opt.maxIndent || 0;
   this.boxes_ = [];
   this.rootBox_ = new Hbox(this);
+
+  this.nestCount_ = 0;
 }
 
 Formatter.MAX_MARGIN = 1e9;
@@ -146,14 +147,18 @@ proto.getMaxIndent = function () {
   return this.maxIndent_;
 };
 
-proto.sprintf = function (format, args___) {
-  var args = Array.prototype.slice.call(arguments, 1);
-  this.printf_a(format, args);
-  return this.printer_.getResult();
-};
-
 proto.printf = function () {
-  console.log(this.sprintf.apply(this, arguments));
+  var format = arguments[0];
+  var args = Array.prototype.slice.call(arguments, 1);
+  try {
+    ++this.nestCount_;
+    this.printf_a_(format, args);
+  } finally {
+    --this.nestCount_;
+  }
+  if (this.nestCount_ === 0)
+    return this.printer_.finish();
+  return undefined;
 };
 
 proto.currentBox_ = function () {
@@ -171,7 +176,7 @@ proto.clipByMaxIndent_ = function (indent) {
   return (this.maxIndent_ > 0) ? Math.min(indent, this.maxIndent_) : indent;
 };
 
-proto.printf_a = function (format, args) {
+proto.printf_a_ = function (format, args) {
   var s = format.match(/^([^@%]*)/)[0];
   if (s.length > 0)
     this.printString(s);
@@ -179,11 +184,11 @@ proto.printf_a = function (format, args) {
   var i = 0;
   function nextArg(type) {
     util.assert(i < args.length,
-                "Formatter#printf_a: given " + args.length + " arguments but not enogugh.");
+                "Formatter#printf_a_: given " + args.length + " arguments but not enogugh.");
     var ret = args[i++];
     if (typeof type === "string") {
       util.assert(typeof ret === type,
-          "Formatter#printf_a: expected " + type + " but " + (typeof ret)
+          "Formatter#printf_a_: expected " + type + " but " + (typeof ret)
             + " is given for the " + util.nth(i + 1) + " argument");
     }
     return ret;
@@ -223,7 +228,7 @@ proto.printf_a = function (format, args) {
         };
         var opener = openers[arg[1]];
         if (!opener) {
-          throw new Error("Fomrater#printf_a: Unknown box @[" + arg[0] + " :" + arg[1]);
+          throw new Error("Fomrater#printf_a_: Unknown box @[" + arg[0] + " :" + arg[1]);
         }
         var additionalIndent = Number(arg[2]) || 0;
         this[opener](additionalIndent, !!sensitiveTable[opener]);
@@ -243,7 +248,7 @@ proto.printf_a = function (format, args) {
       case "@;":
         var arg = trailing.match(/^<(\d*)\s*(\d*)>/) || ["", "", ""];
         if (!(arg[1] && arg[2])) {
-          throw new Error("Fomrater#printf_a: Invalid Format @;" + arg[0]);
+          throw new Error("Fomrater#printf_a_: Invalid Format @;" + arg[0]);
         }
         trailing = trailing.substr(arg[0].length);
         this.printBreak(Number(arg[1]), Number(arg[2]));
@@ -258,7 +263,7 @@ proto.printf_a = function (format, args) {
         this.printString("@");
         break;
       default:
-        throw new Error("Formatter#printf_a: unknown escape:" + atX);
+        throw new Error("Formatter#printf_a_: unknown escape:" + atX);
       }
     } else if (perType) {
       // we found "%"
@@ -308,10 +313,10 @@ proto.printf_a = function (format, args) {
       case "l": case "n": case "L": // no int32, nativeint, int64 in JS
       case "b":                     // deprecated
       case "{": case "(":           // ah... actually I don't know how to use them...
-        util.assert(false, "Formatter#printf_a: unsupported escape sequence: %" + perType);
+        util.assert(false, "Formatter#printf_a_: unsupported escape sequence: %" + perType);
         break;
       default:
-        throw new Error("Formatter#printf_a: unknown escape: %" + perType);
+        throw new Error("Formatter#printf_a_: unknown escape: %" + perType);
       }
     }
     if (trailing.length > 0)

--- a/lib/Printer.js
+++ b/lib/Printer.js
@@ -6,24 +6,34 @@ var Printer = (function () {
   var klass = Printer;
 
   function Printer(opt) {
-	  util.assertObject(opt, "opt");
-	  util.assertFunction(opt.output, "opt.output");
-	  util.assertFunction(opt.getResult, "opt.getResult");
-
-    var hs = util.shallowCopy(opt);
+    var hs = opt ? util.shallowCopy(opt) : {};
+    hs.output || (hs.output = util.ignore);
+    hs.onFinish || (hs.onFinish = util.ignore);
     hs.outputDebug || (hs.outputDebug = util.ignore);
     hs.onString || (hs.onString = util.identity);
     hs.onFlush || (hs.onFlush = util.ignore);
     hs.onSpace || (hs.onSpace = util.spacer);
     hs.onNewline || (hs.onNewline = function () { return "\n"; });
     this.handlers_ = hs;
+    this.buf_ = "";
   }
 
+  /*
   klass.makeStringPrinter = function (opt) {
     var buf = "";
+    function output(s) {
+      buf += s;
+      opt.output && opt.output(s);
+    };
+    function finish() {
+      var ret = buf;
+      buf = "";
+      opt.finish && opt.finish(buf);
+      return ret;
+    }
     var options = {
-      output: function (s) { buf += s; },
-      getResult: function () { var ret = buf; buf = ""; return ret; },
+      output: output,
+      finish: finish,
       outputDebug: opt.outputDebug,
       onString: opt.onString,
       onFlush: opt.onFlush,
@@ -32,6 +42,7 @@ var Printer = (function () {
     };
     return new Printer(options);
   };
+  */
 
   var proto = klass.prototype;
 
@@ -56,13 +67,22 @@ var Printer = (function () {
     this.handlers_.outputDebug(s);
   };
 
-  proto.getResult = function () {
-    return this.handlers_.getResult();
+  proto.finish = function () {
+    var ret = this.buf_;
+    this.buf_ = "";
+    this.handlers_.onFinish(ret);
+    return ret;
+  };
+
+  proto.output_ = function (s) {
+    var hs = this.handlers_;
+    this.buf_ += s;
+    hs.output(s);
   };
 
   proto.outputString = function (s) {
     var hs = this.handlers_;
-    hs.output(hs.onString(s));
+    this.output_(hs.onString(s));
   };
 
   proto.outputFlush = function () {
@@ -71,12 +91,12 @@ var Printer = (function () {
 
   proto.outputSpace = function (n) {
     var hs = this.handlers_;
-    hs.output(hs.onSpace(n));
+    this.output_(hs.onSpace(n));
   };
 
   proto.outputNewline = function () {
     var hs = this.handlers_;
-    hs.output(hs.onNewline());
+    this.output_(hs.onNewline());
   };
 
   return klass;

--- a/lib/Printer.js
+++ b/lib/Printer.js
@@ -18,32 +18,6 @@ var Printer = (function () {
     this.buf_ = "";
   }
 
-  /*
-  klass.makeStringPrinter = function (opt) {
-    var buf = "";
-    function output(s) {
-      buf += s;
-      opt.output && opt.output(s);
-    };
-    function finish() {
-      var ret = buf;
-      buf = "";
-      opt.finish && opt.finish(buf);
-      return ret;
-    }
-    var options = {
-      output: output,
-      finish: finish,
-      outputDebug: opt.outputDebug,
-      onString: opt.onString,
-      onFlush: opt.onFlush,
-      onSpace: opt.onSpace,
-      onNewline: opt.onNewline,
-    };
-    return new Printer(options);
-  };
-  */
-
   var proto = klass.prototype;
 
   var handlerNames = ["onString", "onFlush", "onSpace", "onNewline"];
@@ -64,7 +38,8 @@ var Printer = (function () {
   };
 
   proto.outputDebugString = function (s) {
-    this.handlers_.outputDebug(s);
+    var hs = this.handlers_;
+    hs.outputDebug(s);
   };
 
   proto.finish = function () {

--- a/test-src/makeTest-compat.js
+++ b/test-src/makeTest-compat.js
@@ -32,7 +32,7 @@ function makeAnswer(m, s) {
           +      "printf \\\"" + s + "\\\" | "
           + "ocaml -stdin";
   var result = child_process.execSync(cmd).toString();
-  return result.substr(0, result.length - 1); // remove trailing newline.
+  return result;
 }
 
 var renderer = ECT({ root: __dirname });

--- a/test-src/template-compat.ect
+++ b/test-src/template-compat.ect
@@ -14,7 +14,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(<%- c.margin %>, <%= c.margin - 1 %>);
-    var formatted = ppf.sprintf(<%- c.source %>);
+    var formatted = ppf.printf(<%- c.source %>);
     var expected = <%- c.expected %>;
     expect(formatted).equal(expected);
   });

--- a/test/autogen-compat.spec.js
+++ b/test/autogen-compat.spec.js
@@ -11,11 +11,12 @@ describe("compatibility", function () {
       12345
       aaaaa [b
           c]
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(5, 4);
     var formatted = ppf.printf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
-    var expected = "aaaaa [b\n    c]";
+    var expected = "aaaaa [b\n    c]\n";
     expect(formatted).equal(expected);
   });
 
@@ -25,11 +26,12 @@ describe("compatibility", function () {
       1234567
       aaaaa [b
             c]
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(7, 6);
     var formatted = ppf.printf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
-    var expected = "aaaaa [b\n      c]";
+    var expected = "aaaaa [b\n      c]\n";
     expect(formatted).equal(expected);
   });
 
@@ -39,11 +41,12 @@ describe("compatibility", function () {
       123456789
       aaaaa [b
             c]
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(9, 8);
     var formatted = ppf.printf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
-    var expected = "aaaaa [b\n      c]";
+    var expected = "aaaaa [b\n      c]\n";
     expect(formatted).equal(expected);
   });
 
@@ -53,11 +56,12 @@ describe("compatibility", function () {
       12345678901
       aaaaa [b
             c]
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(11, 10);
     var formatted = ppf.printf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
-    var expected = "aaaaa [b\n      c]";
+    var expected = "aaaaa [b\n      c]\n";
     expect(formatted).equal(expected);
   });
 
@@ -67,11 +71,12 @@ describe("compatibility", function () {
       1234567890123
       aaaaa [b
             c]
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(13, 12);
     var formatted = ppf.printf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
-    var expected = "aaaaa [b\n      c]";
+    var expected = "aaaaa [b\n      c]\n";
     expect(formatted).equal(expected);
   });
 
@@ -81,11 +86,12 @@ describe("compatibility", function () {
       123456789012345
       aaaaa [b
             c]
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
     var formatted = ppf.printf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
-    var expected = "aaaaa [b\n      c]";
+    var expected = "aaaaa [b\n      c]\n";
     expect(formatted).equal(expected);
   });
 
@@ -95,11 +101,12 @@ describe("compatibility", function () {
       12345678901234567
       aaaaa [b
             c]
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(17, 16);
     var formatted = ppf.printf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
-    var expected = "aaaaa [b\n      c]";
+    var expected = "aaaaa [b\n      c]\n";
     expect(formatted).equal(expected);
   });
 
@@ -111,11 +118,12 @@ describe("compatibility", function () {
         eeee
       f
       ggggggggg]
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(3, 2);
     var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
-    var expected = "[ddd\n  eeee\nf\nggggggggg]";
+    var expected = "[ddd\n  eeee\nf\nggggggggg]\n";
     expect(formatted).equal(expected);
   });
 
@@ -127,11 +135,12 @@ describe("compatibility", function () {
          eeee
       f
       ggggggggg]
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(4, 3);
     var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
-    var expected = "[ddd\n   eeee\nf\nggggggggg]";
+    var expected = "[ddd\n   eeee\nf\nggggggggg]\n";
     expect(formatted).equal(expected);
   });
 
@@ -143,11 +152,12 @@ describe("compatibility", function () {
           eeee
       f
       ggggggggg]
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(5, 4);
     var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
-    var expected = "[ddd\n    eeee\nf\nggggggggg]";
+    var expected = "[ddd\n    eeee\nf\nggggggggg]\n";
     expect(formatted).equal(expected);
   });
 
@@ -159,11 +169,12 @@ describe("compatibility", function () {
           eeee
       f
       ggggggggg]
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(6, 5);
     var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
-    var expected = "[ddd\n    eeee\nf\nggggggggg]";
+    var expected = "[ddd\n    eeee\nf\nggggggggg]\n";
     expect(formatted).equal(expected);
   });
 
@@ -175,11 +186,12 @@ describe("compatibility", function () {
           eeee
       f
       ggggggggg]
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(7, 6);
     var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
-    var expected = "[ddd\n    eeee\nf\nggggggggg]";
+    var expected = "[ddd\n    eeee\nf\nggggggggg]\n";
     expect(formatted).equal(expected);
   });
 
@@ -191,11 +203,12 @@ describe("compatibility", function () {
           eeee
       f
       ggggggggg]
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(8, 7);
     var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
-    var expected = "[ddd\n    eeee\nf\nggggggggg]";
+    var expected = "[ddd\n    eeee\nf\nggggggggg]\n";
     expect(formatted).equal(expected);
   });
 
@@ -207,11 +220,12 @@ describe("compatibility", function () {
           eeee
       f
       ggggggggg]
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(9, 8);
     var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
-    var expected = "[ddd\n    eeee\nf\nggggggggg]";
+    var expected = "[ddd\n    eeee\nf\nggggggggg]\n";
     expect(formatted).equal(expected);
   });
 
@@ -223,11 +237,12 @@ describe("compatibility", function () {
           eeee
       f
       ggggggggg]
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(10, 9);
     var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
-    var expected = "[ddd\n    eeee\nf\nggggggggg]";
+    var expected = "[ddd\n    eeee\nf\nggggggggg]\n";
     expect(formatted).equal(expected);
   });
 
@@ -242,11 +257,12 @@ describe("compatibility", function () {
       f gg
       h i
       j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(5, 4);
     var formatted = ppf.printf("@[aa@ bb@ c@ dddd@ eeee@ f@ gg@ h@ i@ j@]@.");
-    var expected = "aa\nbb c\ndddd\neeee\nf gg\nh i\nj";
+    var expected = "aa\nbb c\ndddd\neeee\nf gg\nh i\nj\n";
     expect(formatted).equal(expected);
   });
 
@@ -264,11 +280,12 @@ describe("compatibility", function () {
        h
        i
        j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(5, 4);
     var formatted = ppf.printf("@[<hv 1>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
-    var expected = "aa\n bb\n c\n [ddd\n eeee\n f\n g]\n h\n i\n j";
+    var expected = "aa\n bb\n c\n [ddd\n eeee\n f\n g]\n h\n i\n j\n";
     expect(formatted).equal(expected);
   });
 
@@ -285,11 +302,12 @@ describe("compatibility", function () {
        h
        i
        j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(10, 9);
     var formatted = ppf.printf("@[<hv 1>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
-    var expected = "aa\n bb\n c\n [ddd\n eeee f\n g]\n h\n i\n j";
+    var expected = "aa\n bb\n c\n [ddd\n eeee f\n g]\n h\n i\n j\n";
     expect(formatted).equal(expected);
   });
 
@@ -305,11 +323,12 @@ describe("compatibility", function () {
        h
        i
        j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
     var formatted = ppf.printf("@[<hv 1>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
-    var expected = "aa\n bb\n c\n [ddd eeee f\n g]\n h\n i\n j";
+    var expected = "aa\n bb\n c\n [ddd eeee f\n g]\n h\n i\n j\n";
     expect(formatted).equal(expected);
   });
 
@@ -321,11 +340,12 @@ describe("compatibility", function () {
               eeee
               f
               g] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(10, 9);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee\n        f\n        g] h i j";
+    var expected = "aa bb c [ddd\n        eeee\n        f\n        g] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -337,11 +357,12 @@ describe("compatibility", function () {
               eeee
               f
               g] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(12, 11);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee\n        f\n        g] h i j";
+    var expected = "aa bb c [ddd\n        eeee\n        f\n        g] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -352,11 +373,12 @@ describe("compatibility", function () {
       aa bb c [ddd
               eeee
               f g] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(14, 13);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee\n        f g] h i j";
+    var expected = "aa bb c [ddd\n        eeee\n        f g] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -367,11 +389,12 @@ describe("compatibility", function () {
       aa bb c [ddd
               eeee f
               g] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(17, 16);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee f\n        g] h i j";
+    var expected = "aa bb c [ddd\n        eeee f\n        g] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -381,11 +404,12 @@ describe("compatibility", function () {
       1234567890123456789
       aa bb c [ddd eeee
               f g] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(19, 18);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd eeee\n        f g] h i j";
+    var expected = "aa bb c [ddd eeee\n        f g] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -394,11 +418,12 @@ describe("compatibility", function () {
     /* 
       12345678901234567890123
       aa bb c [ddd eeee f g] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(23, 22);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd eeee f g] h i j";
+    var expected = "aa bb c [ddd eeee f g] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -410,11 +435,12 @@ describe("compatibility", function () {
               eeee
               f
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(9, 8);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee\n        f\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        eeee\n        f\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -426,11 +452,12 @@ describe("compatibility", function () {
               eeee
               f
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(11, 10);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee\n        f\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        eeee\n        f\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -442,11 +469,12 @@ describe("compatibility", function () {
               eeee
               f
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(12, 11);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee\n        f\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        eeee\n        f\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -458,11 +486,12 @@ describe("compatibility", function () {
               eeee
               f
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(13, 12);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee\n        f\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        eeee\n        f\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -474,11 +503,12 @@ describe("compatibility", function () {
               eeee
               f
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(14, 13);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee\n        f\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        eeee\n        f\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -489,11 +519,12 @@ describe("compatibility", function () {
       aa bb c [ddd
               eeee f
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee f\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        eeee f\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -505,11 +536,12 @@ describe("compatibility", function () {
                eeee
                f
                ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(12, 11);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[<1>[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n         eeee\n         f\n         ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n         eeee\n         f\n         ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -521,11 +553,12 @@ describe("compatibility", function () {
                eeee
                f
                ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(14, 13);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[<1>[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n         eeee\n         f\n         ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n         eeee\n         f\n         ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -537,11 +570,12 @@ describe("compatibility", function () {
                eeee
                f
                ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[<1>[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n         eeee\n         f\n         ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n         eeee\n         f\n         ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -551,11 +585,12 @@ describe("compatibility", function () {
       1234567890123456789012
       aa bb c [ddd eeee f
                ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(22, 21);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[<1>[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd eeee f\n         ggggggggg] h i j";
+    var expected = "aa bb c [ddd eeee f\n         ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -567,11 +602,12 @@ describe("compatibility", function () {
                  eeee
               f
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n           eeee\n        f\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n           eeee\n        f\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -583,11 +619,12 @@ describe("compatibility", function () {
                  eeee
               f
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(18, 17);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n           eeee\n        f\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n           eeee\n        f\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -599,11 +636,12 @@ describe("compatibility", function () {
                  eeee
               f
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(19, 18);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n           eeee\n        f\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n           eeee\n        f\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -615,11 +653,12 @@ describe("compatibility", function () {
                  eeee
               f
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(20, 19);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n           eeee\n        f\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n           eeee\n        f\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -630,11 +669,12 @@ describe("compatibility", function () {
       aa bb c [ddd
                  eeee
               f ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(21, 20);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n           eeee\n        f ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n           eeee\n        f ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -646,11 +686,12 @@ describe("compatibility", function () {
                eeee
             f
             ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
     var formatted = ppf.printf("@[<h>a@ b@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "a b c [ddd\n         eeee\n      f\n      ggggggggg] h i j";
+    var expected = "a b c [ddd\n         eeee\n      f\n      ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -662,11 +703,12 @@ describe("compatibility", function () {
                eeee
             f
             ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(18, 17);
     var formatted = ppf.printf("@[<h>a@ b@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "a b c [ddd\n         eeee\n      f\n      ggggggggg] h i j";
+    var expected = "a b c [ddd\n         eeee\n      f\n      ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -677,11 +719,12 @@ describe("compatibility", function () {
       a b c [ddd
                eeee
             f ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(19, 18);
     var formatted = ppf.printf("@[<h>a@ b@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "a b c [ddd\n         eeee\n      f ggggggggg] h i j";
+    var expected = "a b c [ddd\n         eeee\n      f ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -692,11 +735,12 @@ describe("compatibility", function () {
       a b c [ddd
                eeee
             f ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(20, 19);
     var formatted = ppf.printf("@[<h>a@ b@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "a b c [ddd\n         eeee\n      f ggggggggg] h i j";
+    var expected = "a b c [ddd\n         eeee\n      f ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -706,11 +750,12 @@ describe("compatibility", function () {
       123456789012345678901
       a b c [ddd      eeee
             f ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(21, 20);
     var formatted = ppf.printf("@[<h>a@ b@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "a b c [ddd      eeee\n      f ggggggggg] h i j";
+    var expected = "a b c [ddd      eeee\n      f ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -722,11 +767,12 @@ describe("compatibility", function () {
               eeee
           f
           ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
     var formatted = ppf.printf("@[<h>abc@ @[[ddd@;<6 4>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "abc [ddd\n        eeee\n    f\n    ggggggggg] h i j";
+    var expected = "abc [ddd\n        eeee\n    f\n    ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -737,11 +783,12 @@ describe("compatibility", function () {
       abc [ddd
               eeee
           f ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(18, 17);
     var formatted = ppf.printf("@[<h>abc@ @[[ddd@;<6 4>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "abc [ddd\n        eeee\n    f ggggggggg] h i j";
+    var expected = "abc [ddd\n        eeee\n    f ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -751,11 +798,12 @@ describe("compatibility", function () {
       1234567890123456789
       abc [ddd      eeee
           f ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(19, 18);
     var formatted = ppf.printf("@[<h>abc@ @[[ddd@;<6 4>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "abc [ddd      eeee\n    f ggggggggg] h i j";
+    var expected = "abc [ddd      eeee\n    f ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -765,11 +813,12 @@ describe("compatibility", function () {
       12345678901234567890
       abc [ddd      eeee
           f ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(20, 19);
     var formatted = ppf.printf("@[<h>abc@ @[[ddd@;<6 4>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "abc [ddd      eeee\n    f ggggggggg] h i j";
+    var expected = "abc [ddd      eeee\n    f ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -779,11 +828,12 @@ describe("compatibility", function () {
       123456789012345678901
       abc [ddd      eeee f
           ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(21, 20);
     var formatted = ppf.printf("@[<h>abc@ @[[ddd@;<6 4>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "abc [ddd      eeee f\n    ggggggggg] h i j";
+    var expected = "abc [ddd      eeee f\n    ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -795,11 +845,12 @@ describe("compatibility", function () {
               eeee
               ff
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(9, 8);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -811,11 +862,12 @@ describe("compatibility", function () {
               eeee
               ff
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(11, 10);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -827,11 +879,12 @@ describe("compatibility", function () {
               eeee
               ff
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(12, 11);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -843,11 +896,12 @@ describe("compatibility", function () {
               eeee
               ff
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(13, 12);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -859,11 +913,12 @@ describe("compatibility", function () {
               eeee
               ff
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(14, 13);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -875,11 +930,12 @@ describe("compatibility", function () {
               eeee
               ff
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -891,11 +947,12 @@ describe("compatibility", function () {
            eeeeeeeeeeeeeeeeeeeeeeeee
            ff
            ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(6, 5);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeeeeeeeeeeeeeeeeeeeeeeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n     eeeeeeeeeeeeeeeeeeeeeeeee\n     ff\n     ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n     eeeeeeeeeeeeeeeeeeeeeeeee\n     ff\n     ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -907,11 +964,12 @@ describe("compatibility", function () {
             eeeeeeeeeeeeeeeeeeeeeeeee
             ff
             ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(7, 6);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeeeeeeeeeeeeeeeeeeeeeeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n      eeeeeeeeeeeeeeeeeeeeeeeee\n      ff\n      ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n      eeeeeeeeeeeeeeeeeeeeeeeee\n      ff\n      ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -923,11 +981,12 @@ describe("compatibility", function () {
               eeeeeeeeeeeeeeeeeeeeeeeee
               ff
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(9, 8);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeeeeeeeeeeeeeeeeeeeeeeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeeeeeeeeeeeeeeeeeeeeeeee\n        ff\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        eeeeeeeeeeeeeeeeeeeeeeeee\n        ff\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -939,11 +998,12 @@ describe("compatibility", function () {
               eeeeeeeeeeeeeeeeeeeeeeeee
               ff
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(11, 10);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeeeeeeeeeeeeeeeeeeeeeeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeeeeeeeeeeeeeeeeeeeeeeee\n        ff\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        eeeeeeeeeeeeeeeeeeeeeeeee\n        ff\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -955,11 +1015,12 @@ describe("compatibility", function () {
               eeeeeeeeeeeeeeeeeeeeeeeee
               ff
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(12, 11);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeeeeeeeeeeeeeeeeeeeeeeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        eeeeeeeeeeeeeeeeeeeeeeeee\n        ff\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        eeeeeeeeeeeeeeeeeeeeeeeee\n        ff\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -975,11 +1036,12 @@ describe("compatibility", function () {
               ee]
               ff
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(9, 8);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ @[[ee@ ee@ e@ ee@ ee]@]@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        [ee\n        ee\n        e\n        ee\n        ee]\n        ff\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        [ee\n        ee\n        e\n        ee\n        ee]\n        ff\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -995,11 +1057,12 @@ describe("compatibility", function () {
               ee]
               ff
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(11, 10);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ @[[ee@ ee@ e@ ee@ ee]@]@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        [ee\n        ee\n        e\n        ee\n        ee]\n        ff\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        [ee\n        ee\n        e\n        ee\n        ee]\n        ff\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -1014,11 +1077,12 @@ describe("compatibility", function () {
               ee]
               ff
               ggggggggg] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(13, 12);
     var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ @[[ee@ ee@ e@ ee@ ee]@]@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd\n        [ee\n        ee e\n        ee\n        ee]\n        ff\n        ggggggggg] h i j";
+    var expected = "aa bb c [ddd\n        [ee\n        ee e\n        ee\n        ee]\n        ff\n        ggggggggg] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -1029,11 +1093,12 @@ describe("compatibility", function () {
       aa bb c
       [ddd eeee f
       g] h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(13, 12);
     var formatted = ppf.printf("@[aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c\n[ddd eeee f\ng] h i j";
+    var expected = "aa bb c\n[ddd eeee f\ng] h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -1044,11 +1109,12 @@ describe("compatibility", function () {
       aa bb c
       [ddd eeee f g] h
       i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(17, 16);
     var formatted = ppf.printf("@[aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c\n[ddd eeee f g] h\ni j";
+    var expected = "aa bb c\n[ddd eeee f g] h\ni j\n";
     expect(formatted).equal(expected);
   });
 
@@ -1058,11 +1124,12 @@ describe("compatibility", function () {
       12345678901234567890123
       aa bb c [ddd eeee f g]
       h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(23, 22);
     var formatted = ppf.printf("@[aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
-    var expected = "aa bb c [ddd eeee f g]\nh i j";
+    var expected = "aa bb c [ddd eeee f g]\nh i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -1080,11 +1147,12 @@ describe("compatibility", function () {
       h
       i
       j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(5, 4);
     var formatted = ppf.printf("@[<hv>aa@ bb@ c@ dddd@ eeee@ f@ gg@ h@ i@ j@]@.");
-    var expected = "aa\nbb\nc\ndddd\neeee\nf\ngg\nh\ni\nj";
+    var expected = "aa\nbb\nc\ndddd\neeee\nf\ngg\nh\ni\nj\n";
     expect(formatted).equal(expected);
   });
 
@@ -1102,11 +1170,12 @@ describe("compatibility", function () {
       h
       i
       j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(20, 19);
     var formatted = ppf.printf("@[<hv>aa@ bb@ c@ dddd@ eeee@ f@ gg@ h@ i@ j@]@.");
-    var expected = "aa\nbb\nc\ndddd\neeee\nf\ngg\nh\ni\nj";
+    var expected = "aa\nbb\nc\ndddd\neeee\nf\ngg\nh\ni\nj\n";
     expect(formatted).equal(expected);
   });
 
@@ -1115,11 +1184,12 @@ describe("compatibility", function () {
     /* 
       1234567890123456789012345678901234567890
       aa bb c dddd eeee f gg h i j
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(40, 39);
     var formatted = ppf.printf("@[<hv>aa@ bb@ c@ dddd@ eeee@ f@ gg@ h@ i@ j@]@.");
-    var expected = "aa bb c dddd eeee f gg h i j";
+    var expected = "aa bb c dddd eeee f gg h i j\n";
     expect(formatted).equal(expected);
   });
 
@@ -1130,11 +1200,12 @@ describe("compatibility", function () {
       aaa b
           cccccccccc
           zzz
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(7, 6);
     var formatted = ppf.printf("@[aaa @[<hov>b@ cccccccccc@ @]zzz@]@.");
-    var expected = "aaa b\n    cccccccccc\n    zzz";
+    var expected = "aaa b\n    cccccccccc\n    zzz\n";
     expect(formatted).equal(expected);
   });
 
@@ -1145,11 +1216,12 @@ describe("compatibility", function () {
       aaa b
           cccccccccc
           zzz
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(10, 9);
     var formatted = ppf.printf("@[aaa @[<hov>b@ cccccccccc@ @]zzz@]@.");
-    var expected = "aaa b\n    cccccccccc\n    zzz";
+    var expected = "aaa b\n    cccccccccc\n    zzz\n";
     expect(formatted).equal(expected);
   });
 
@@ -1159,11 +1231,12 @@ describe("compatibility", function () {
       1234567
       aaa bbbbbbbbbb
           ccc
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(7, 6);
     var formatted = ppf.printf("@[aaa @[bbbbbbbbbb@ @]ccc@]@.");
-    var expected = "aaa bbbbbbbbbb\n    ccc";
+    var expected = "aaa bbbbbbbbbb\n    ccc\n";
     expect(formatted).equal(expected);
   });
 
@@ -1173,11 +1246,12 @@ describe("compatibility", function () {
       1234567890
       aaa bbbbbbbbbb
           ccc
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(10, 9);
     var formatted = ppf.printf("@[aaa @[bbbbbbbbbb@ @]ccc@]@.");
-    var expected = "aaa bbbbbbbbbb\n    ccc";
+    var expected = "aaa bbbbbbbbbb\n    ccc\n";
     expect(formatted).equal(expected);
   });
 
@@ -1187,11 +1261,12 @@ describe("compatibility", function () {
       1234567
       aaa bbbbbbbbbb
           ccc
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(7, 6);
     var formatted = ppf.printf("@[aaa @[bbbbbbbbbb@ @]@]ccc@.");
-    var expected = "aaa bbbbbbbbbb\n    ccc";
+    var expected = "aaa bbbbbbbbbb\n    ccc\n";
     expect(formatted).equal(expected);
   });
 
@@ -1201,11 +1276,12 @@ describe("compatibility", function () {
       1234567890
       aaa bbbbbbbbbb
           ccc
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(10, 9);
     var formatted = ppf.printf("@[aaa @[bbbbbbbbbb@ @]@]ccc@.");
-    var expected = "aaa bbbbbbbbbb\n    ccc";
+    var expected = "aaa bbbbbbbbbb\n    ccc\n";
     expect(formatted).equal(expected);
   });
 
@@ -1218,11 +1294,12 @@ describe("compatibility", function () {
       bbb
       ccccc]
       zzz
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(6, 5);
     var formatted = ppf.printf("@[foo@ @[[aaaa@ bbb@ ccccc]@]@ zzz@]@.");
-    var expected = "foo\n[aaaa\nbbb\nccccc]\nzzz";
+    var expected = "foo\n[aaaa\nbbb\nccccc]\nzzz\n";
     expect(formatted).equal(expected);
   });
 
@@ -1233,11 +1310,12 @@ describe("compatibility", function () {
       foo
       [aaaa bbb ccccc]
       zzz
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(20, 19);
     var formatted = ppf.printf("@[foo@ @[[aaaa@ bbb@ ccccc]@]@ zzz@]@.");
-    var expected = "foo\n[aaaa bbb ccccc]\nzzz";
+    var expected = "foo\n[aaaa bbb ccccc]\nzzz\n";
     expect(formatted).equal(expected);
   });
 
@@ -1250,11 +1328,12 @@ describe("compatibility", function () {
       bbb
       cccc]
       zzz
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(6, 5);
     var formatted = ppf.printf("@[foo@ @[[aaaa@\nbbb@ cccc]@]@ zzz@]@.");
-    var expected = "foo\n[aaaa\nbbb\ncccc]\nzzz";
+    var expected = "foo\n[aaaa\nbbb\ncccc]\nzzz\n";
     expect(formatted).equal(expected);
   });
 
@@ -1266,11 +1345,12 @@ describe("compatibility", function () {
       [aaaa
       bbb cccc]
       zzz
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(10, 9);
     var formatted = ppf.printf("@[foo@ @[[aaaa@\nbbb@ cccc]@]@ zzz@]@.");
-    var expected = "foo\n[aaaa\nbbb cccc]\nzzz";
+    var expected = "foo\n[aaaa\nbbb cccc]\nzzz\n";
     expect(formatted).equal(expected);
   });
 
@@ -1281,11 +1361,12 @@ describe("compatibility", function () {
       foo [aaaa
           bbb cccc]
       zzz
+      
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(20, 19);
     var formatted = ppf.printf("@[foo@ @[[aaaa@\nbbb@ cccc]@]@ zzz@]@.");
-    var expected = "foo [aaaa\n    bbb cccc]\nzzz";
+    var expected = "foo [aaaa\n    bbb cccc]\nzzz\n";
     expect(formatted).equal(expected);
   });
 

--- a/test/autogen-compat.spec.js
+++ b/test/autogen-compat.spec.js
@@ -14,7 +14,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(5, 4);
-    var formatted = ppf.sprintf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
+    var formatted = ppf.printf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
     var expected = "aaaaa [b\n    c]";
     expect(formatted).equal(expected);
   });
@@ -28,7 +28,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(7, 6);
-    var formatted = ppf.sprintf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
+    var formatted = ppf.printf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
     var expected = "aaaaa [b\n      c]";
     expect(formatted).equal(expected);
   });
@@ -42,7 +42,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(9, 8);
-    var formatted = ppf.sprintf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
+    var formatted = ppf.printf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
     var expected = "aaaaa [b\n      c]";
     expect(formatted).equal(expected);
   });
@@ -56,7 +56,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(11, 10);
-    var formatted = ppf.sprintf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
+    var formatted = ppf.printf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
     var expected = "aaaaa [b\n      c]";
     expect(formatted).equal(expected);
   });
@@ -70,7 +70,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(13, 12);
-    var formatted = ppf.sprintf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
+    var formatted = ppf.printf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
     var expected = "aaaaa [b\n      c]";
     expect(formatted).equal(expected);
   });
@@ -84,7 +84,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
-    var formatted = ppf.sprintf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
+    var formatted = ppf.printf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
     var expected = "aaaaa [b\n      c]";
     expect(formatted).equal(expected);
   });
@@ -98,7 +98,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(17, 16);
-    var formatted = ppf.sprintf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
+    var formatted = ppf.printf("@[<h>aaaaa@ @[<v>[b@ c]@]@]@.");
     var expected = "aaaaa [b\n      c]";
     expect(formatted).equal(expected);
   });
@@ -114,7 +114,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(3, 2);
-    var formatted = ppf.sprintf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
+    var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
     var expected = "[ddd\n  eeee\nf\nggggggggg]";
     expect(formatted).equal(expected);
   });
@@ -130,7 +130,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(4, 3);
-    var formatted = ppf.sprintf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
+    var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
     var expected = "[ddd\n   eeee\nf\nggggggggg]";
     expect(formatted).equal(expected);
   });
@@ -146,7 +146,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(5, 4);
-    var formatted = ppf.sprintf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
+    var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
     var expected = "[ddd\n    eeee\nf\nggggggggg]";
     expect(formatted).equal(expected);
   });
@@ -162,7 +162,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(6, 5);
-    var formatted = ppf.sprintf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
+    var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
     var expected = "[ddd\n    eeee\nf\nggggggggg]";
     expect(formatted).equal(expected);
   });
@@ -178,7 +178,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(7, 6);
-    var formatted = ppf.sprintf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
+    var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
     var expected = "[ddd\n    eeee\nf\nggggggggg]";
     expect(formatted).equal(expected);
   });
@@ -194,7 +194,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(8, 7);
-    var formatted = ppf.sprintf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
+    var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
     var expected = "[ddd\n    eeee\nf\nggggggggg]";
     expect(formatted).equal(expected);
   });
@@ -210,7 +210,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(9, 8);
-    var formatted = ppf.sprintf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
+    var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
     var expected = "[ddd\n    eeee\nf\nggggggggg]";
     expect(formatted).equal(expected);
   });
@@ -226,7 +226,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(10, 9);
-    var formatted = ppf.sprintf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
+    var formatted = ppf.printf("@[[ddd@;<2 4>eeee@ f@ ggggggggg]@]@.");
     var expected = "[ddd\n    eeee\nf\nggggggggg]";
     expect(formatted).equal(expected);
   });
@@ -245,7 +245,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(5, 4);
-    var formatted = ppf.sprintf("@[aa@ bb@ c@ dddd@ eeee@ f@ gg@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[aa@ bb@ c@ dddd@ eeee@ f@ gg@ h@ i@ j@]@.");
     var expected = "aa\nbb c\ndddd\neeee\nf gg\nh i\nj";
     expect(formatted).equal(expected);
   });
@@ -267,7 +267,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(5, 4);
-    var formatted = ppf.sprintf("@[<hv 1>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<hv 1>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
     var expected = "aa\n bb\n c\n [ddd\n eeee\n f\n g]\n h\n i\n j";
     expect(formatted).equal(expected);
   });
@@ -288,7 +288,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(10, 9);
-    var formatted = ppf.sprintf("@[<hv 1>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<hv 1>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
     var expected = "aa\n bb\n c\n [ddd\n eeee f\n g]\n h\n i\n j";
     expect(formatted).equal(expected);
   });
@@ -308,7 +308,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
-    var formatted = ppf.sprintf("@[<hv 1>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<hv 1>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
     var expected = "aa\n bb\n c\n [ddd eeee f\n g]\n h\n i\n j";
     expect(formatted).equal(expected);
   });
@@ -324,7 +324,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(10, 9);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee\n        f\n        g] h i j";
     expect(formatted).equal(expected);
   });
@@ -340,7 +340,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(12, 11);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee\n        f\n        g] h i j";
     expect(formatted).equal(expected);
   });
@@ -355,7 +355,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(14, 13);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee\n        f g] h i j";
     expect(formatted).equal(expected);
   });
@@ -370,7 +370,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(17, 16);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee f\n        g] h i j";
     expect(formatted).equal(expected);
   });
@@ -384,7 +384,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(19, 18);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd eeee\n        f g] h i j";
     expect(formatted).equal(expected);
   });
@@ -397,7 +397,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(23, 22);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd eeee f g] h i j";
     expect(formatted).equal(expected);
   });
@@ -413,7 +413,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(9, 8);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee\n        f\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -429,7 +429,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(11, 10);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee\n        f\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -445,7 +445,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(12, 11);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee\n        f\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -461,7 +461,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(13, 12);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee\n        f\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -477,7 +477,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(14, 13);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee\n        f\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -492,7 +492,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee f\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -508,7 +508,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(12, 11);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[<1>[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[<1>[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n         eeee\n         f\n         ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -524,7 +524,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(14, 13);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[<1>[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[<1>[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n         eeee\n         f\n         ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -540,7 +540,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[<1>[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[<1>[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n         eeee\n         f\n         ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -554,7 +554,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(22, 21);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[<1>[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[<1>[ddd@ eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd eeee f\n         ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -570,7 +570,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n           eeee\n        f\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -586,7 +586,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(18, 17);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n           eeee\n        f\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -602,7 +602,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(19, 18);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n           eeee\n        f\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -618,7 +618,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(20, 19);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n           eeee\n        f\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -633,7 +633,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(21, 20);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n           eeee\n        f ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -649,7 +649,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
-    var formatted = ppf.sprintf("@[<h>a@ b@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>a@ b@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "a b c [ddd\n         eeee\n      f\n      ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -665,7 +665,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(18, 17);
-    var formatted = ppf.sprintf("@[<h>a@ b@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>a@ b@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "a b c [ddd\n         eeee\n      f\n      ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -680,7 +680,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(19, 18);
-    var formatted = ppf.sprintf("@[<h>a@ b@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>a@ b@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "a b c [ddd\n         eeee\n      f ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -695,7 +695,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(20, 19);
-    var formatted = ppf.sprintf("@[<h>a@ b@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>a@ b@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "a b c [ddd\n         eeee\n      f ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -709,7 +709,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(21, 20);
-    var formatted = ppf.sprintf("@[<h>a@ b@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>a@ b@ c@ @[[ddd@;<6 3>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "a b c [ddd      eeee\n      f ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -725,7 +725,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
-    var formatted = ppf.sprintf("@[<h>abc@ @[[ddd@;<6 4>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>abc@ @[[ddd@;<6 4>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "abc [ddd\n        eeee\n    f\n    ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -740,7 +740,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(18, 17);
-    var formatted = ppf.sprintf("@[<h>abc@ @[[ddd@;<6 4>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>abc@ @[[ddd@;<6 4>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "abc [ddd\n        eeee\n    f ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -754,7 +754,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(19, 18);
-    var formatted = ppf.sprintf("@[<h>abc@ @[[ddd@;<6 4>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>abc@ @[[ddd@;<6 4>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "abc [ddd      eeee\n    f ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -768,7 +768,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(20, 19);
-    var formatted = ppf.sprintf("@[<h>abc@ @[[ddd@;<6 4>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>abc@ @[[ddd@;<6 4>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "abc [ddd      eeee\n    f ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -782,7 +782,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(21, 20);
-    var formatted = ppf.sprintf("@[<h>abc@ @[[ddd@;<6 4>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>abc@ @[[ddd@;<6 4>eeee@ f@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "abc [ddd      eeee f\n    ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -798,7 +798,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(9, 8);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -814,7 +814,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(11, 10);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -830,7 +830,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(12, 11);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -846,7 +846,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(13, 12);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -862,7 +862,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(14, 13);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -878,7 +878,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(15, 14);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeee\n        ff\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -894,7 +894,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(6, 5);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeeeeeeeeeeeeeeeeeeeeeeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeeeeeeeeeeeeeeeeeeeeeeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n     eeeeeeeeeeeeeeeeeeeeeeeee\n     ff\n     ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -910,7 +910,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(7, 6);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeeeeeeeeeeeeeeeeeeeeeeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeeeeeeeeeeeeeeeeeeeeeeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n      eeeeeeeeeeeeeeeeeeeeeeeee\n      ff\n      ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -926,7 +926,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(9, 8);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeeeeeeeeeeeeeeeeeeeeeeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeeeeeeeeeeeeeeeeeeeeeeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeeeeeeeeeeeeeeeeeeeeeeee\n        ff\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -942,7 +942,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(11, 10);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeeeeeeeeeeeeeeeeeeeeeeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeeeeeeeeeeeeeeeeeeeeeeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeeeeeeeeeeeeeeeeeeeeeeee\n        ff\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -958,7 +958,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(12, 11);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ eeeeeeeeeeeeeeeeeeeeeeeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ eeeeeeeeeeeeeeeeeeeeeeeee@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        eeeeeeeeeeeeeeeeeeeeeeeee\n        ff\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -978,7 +978,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(9, 8);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ @[[ee@ ee@ e@ ee@ ee]@]@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ @[[ee@ ee@ e@ ee@ ee]@]@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        [ee\n        ee\n        e\n        ee\n        ee]\n        ff\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -998,7 +998,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(11, 10);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ @[[ee@ ee@ e@ ee@ ee]@]@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ @[[ee@ ee@ e@ ee@ ee]@]@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        [ee\n        ee\n        e\n        ee\n        ee]\n        ff\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -1017,7 +1017,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(13, 12);
-    var formatted = ppf.sprintf("@[<h>aa@ bb@ c@ @[[ddd@ @[[ee@ ee@ e@ ee@ ee]@]@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<h>aa@ bb@ c@ @[[ddd@ @[[ee@ ee@ e@ ee@ ee]@]@ ff@ ggggggggg]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd\n        [ee\n        ee e\n        ee\n        ee]\n        ff\n        ggggggggg] h i j";
     expect(formatted).equal(expected);
   });
@@ -1032,7 +1032,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(13, 12);
-    var formatted = ppf.sprintf("@[aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
     var expected = "aa bb c\n[ddd eeee f\ng] h i j";
     expect(formatted).equal(expected);
   });
@@ -1047,7 +1047,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(17, 16);
-    var formatted = ppf.sprintf("@[aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
     var expected = "aa bb c\n[ddd eeee f g] h\ni j";
     expect(formatted).equal(expected);
   });
@@ -1061,7 +1061,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(23, 22);
-    var formatted = ppf.sprintf("@[aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[aa@ bb@ c@ @[[ddd@ eeee@ f@ g]@]@ h@ i@ j@]@.");
     var expected = "aa bb c [ddd eeee f g]\nh i j";
     expect(formatted).equal(expected);
   });
@@ -1083,7 +1083,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(5, 4);
-    var formatted = ppf.sprintf("@[<hv>aa@ bb@ c@ dddd@ eeee@ f@ gg@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<hv>aa@ bb@ c@ dddd@ eeee@ f@ gg@ h@ i@ j@]@.");
     var expected = "aa\nbb\nc\ndddd\neeee\nf\ngg\nh\ni\nj";
     expect(formatted).equal(expected);
   });
@@ -1105,7 +1105,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(20, 19);
-    var formatted = ppf.sprintf("@[<hv>aa@ bb@ c@ dddd@ eeee@ f@ gg@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<hv>aa@ bb@ c@ dddd@ eeee@ f@ gg@ h@ i@ j@]@.");
     var expected = "aa\nbb\nc\ndddd\neeee\nf\ngg\nh\ni\nj";
     expect(formatted).equal(expected);
   });
@@ -1118,7 +1118,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(40, 39);
-    var formatted = ppf.sprintf("@[<hv>aa@ bb@ c@ dddd@ eeee@ f@ gg@ h@ i@ j@]@.");
+    var formatted = ppf.printf("@[<hv>aa@ bb@ c@ dddd@ eeee@ f@ gg@ h@ i@ j@]@.");
     var expected = "aa bb c dddd eeee f gg h i j";
     expect(formatted).equal(expected);
   });
@@ -1133,7 +1133,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(7, 6);
-    var formatted = ppf.sprintf("@[aaa @[<hov>b@ cccccccccc@ @]zzz@]@.");
+    var formatted = ppf.printf("@[aaa @[<hov>b@ cccccccccc@ @]zzz@]@.");
     var expected = "aaa b\n    cccccccccc\n    zzz";
     expect(formatted).equal(expected);
   });
@@ -1148,7 +1148,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(10, 9);
-    var formatted = ppf.sprintf("@[aaa @[<hov>b@ cccccccccc@ @]zzz@]@.");
+    var formatted = ppf.printf("@[aaa @[<hov>b@ cccccccccc@ @]zzz@]@.");
     var expected = "aaa b\n    cccccccccc\n    zzz";
     expect(formatted).equal(expected);
   });
@@ -1162,7 +1162,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(7, 6);
-    var formatted = ppf.sprintf("@[aaa @[bbbbbbbbbb@ @]ccc@]@.");
+    var formatted = ppf.printf("@[aaa @[bbbbbbbbbb@ @]ccc@]@.");
     var expected = "aaa bbbbbbbbbb\n    ccc";
     expect(formatted).equal(expected);
   });
@@ -1176,7 +1176,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(10, 9);
-    var formatted = ppf.sprintf("@[aaa @[bbbbbbbbbb@ @]ccc@]@.");
+    var formatted = ppf.printf("@[aaa @[bbbbbbbbbb@ @]ccc@]@.");
     var expected = "aaa bbbbbbbbbb\n    ccc";
     expect(formatted).equal(expected);
   });
@@ -1190,7 +1190,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(7, 6);
-    var formatted = ppf.sprintf("@[aaa @[bbbbbbbbbb@ @]@]ccc@.");
+    var formatted = ppf.printf("@[aaa @[bbbbbbbbbb@ @]@]ccc@.");
     var expected = "aaa bbbbbbbbbb\n    ccc";
     expect(formatted).equal(expected);
   });
@@ -1204,7 +1204,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(10, 9);
-    var formatted = ppf.sprintf("@[aaa @[bbbbbbbbbb@ @]@]ccc@.");
+    var formatted = ppf.printf("@[aaa @[bbbbbbbbbb@ @]@]ccc@.");
     var expected = "aaa bbbbbbbbbb\n    ccc";
     expect(formatted).equal(expected);
   });
@@ -1221,7 +1221,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(6, 5);
-    var formatted = ppf.sprintf("@[foo@ @[[aaaa@ bbb@ ccccc]@]@ zzz@]@.");
+    var formatted = ppf.printf("@[foo@ @[[aaaa@ bbb@ ccccc]@]@ zzz@]@.");
     var expected = "foo\n[aaaa\nbbb\nccccc]\nzzz";
     expect(formatted).equal(expected);
   });
@@ -1236,7 +1236,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(20, 19);
-    var formatted = ppf.sprintf("@[foo@ @[[aaaa@ bbb@ ccccc]@]@ zzz@]@.");
+    var formatted = ppf.printf("@[foo@ @[[aaaa@ bbb@ ccccc]@]@ zzz@]@.");
     var expected = "foo\n[aaaa bbb ccccc]\nzzz";
     expect(formatted).equal(expected);
   });
@@ -1253,7 +1253,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(6, 5);
-    var formatted = ppf.sprintf("@[foo@ @[[aaaa@\nbbb@ cccc]@]@ zzz@]@.");
+    var formatted = ppf.printf("@[foo@ @[[aaaa@\nbbb@ cccc]@]@ zzz@]@.");
     var expected = "foo\n[aaaa\nbbb\ncccc]\nzzz";
     expect(formatted).equal(expected);
   });
@@ -1269,7 +1269,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(10, 9);
-    var formatted = ppf.sprintf("@[foo@ @[[aaaa@\nbbb@ cccc]@]@ zzz@]@.");
+    var formatted = ppf.printf("@[foo@ @[[aaaa@\nbbb@ cccc]@]@ zzz@]@.");
     var expected = "foo\n[aaaa\nbbb cccc]\nzzz";
     expect(formatted).equal(expected);
   });
@@ -1284,7 +1284,7 @@ describe("compatibility", function () {
      */
     var ppf = new pp.Formatter();
     ppf.setMargin(20, 19);
-    var formatted = ppf.sprintf("@[foo@ @[[aaaa@\nbbb@ cccc]@]@ zzz@]@.");
+    var formatted = ppf.printf("@[foo@ @[[aaaa@\nbbb@ cccc]@]@ zzz@]@.");
     var expected = "foo [aaaa\n    bbb cccc]\nzzz";
     expect(formatted).equal(expected);
   });


### PR DESCRIPTION
- Fix printf()'s excessive newline.
- Fix interpretation of "@.": printNewline() but not printFlush().
