### PR TITLE
Fix printBreak() without parameters

### DIFF
--- a/lib/Formatter.js
+++ b/lib/Formatter.js
@@ -279,11 +279,16 @@ proto.printf_a_ = function (format, args) {
         break;
       case "@;":
         var arg = trailing.match(/^<(\d*)\s*(\d*)>/) || ["", "", ""];
+        var nspaces, offset;
         if (!(arg[1] && arg[2])) {
-          throw new Error("Fomrater#printf_a_: Invalid Format @;" + arg[0]);
+          nspaces = 1;
+          offset = 0;
+        } else {
+          nspaces = Number(arg[1]);
+          offset = Number(arg[2]);
         }
         trailing = trailing.substr(arg[0].length);
-        this.printBreak(Number(arg[1]), Number(arg[2]));
+        this.printBreak(nspaces, offset);
         break;
       case "@?":
         this.printFlush();

--- a/lib/Formatter.js
+++ b/lib/Formatter.js
@@ -64,12 +64,6 @@ proto.openHovbox = function (additionalIndent, sensitive) {
   return this.openBoxX_(new Hovbox(this, additionalIndent, sensitive));
 };
 
-proto.flush_ = function () {
-  this.rootBox_.print(0, 0);
-  this.rootBox_.clear();
-  this.printer_.outputFlush();
-};
-
 proto.closeBox = function () {
   this.boxes_.pop();
   if (this.boxes_.length === 0)
@@ -206,6 +200,12 @@ proto.openBoxX_ = function (box) {
 
 proto.clipByMaxIndent_ = function (indent) {
   return (this.maxIndent_ > 0) ? Math.min(indent, this.maxIndent_) : indent;
+};
+
+proto.flush_ = function () {
+  this.rootBox_.print(0, 0);
+  this.rootBox_.clear();
+  this.printer_.outputFlush();
 };
 
 proto.printf_a_ = function (format, args) {

--- a/test/general.spec.js
+++ b/test/general.spec.js
@@ -64,4 +64,16 @@ describe("general", function () {
     expect(lastFinished).to.equal(a);
   });
 
+  it("treats break hints", function () {
+    var mgn = pp.getStrMargin(), mi = pp.getStrMaxIndent();
+    try {
+      pp.setStrMargin(20, 19);
+      var s = pp.sprintf("@[foo@;bar@]@?");
+      var a = "foo bar";
+      expect(s).to.equal(a);
+    } finally {
+      pp.setStrMargin(mgn, mi);
+    }
+  });
+
 });


### PR DESCRIPTION
- Fix `Formatter#printBreak()` without parameters.
- Add a test.
