### PR TITLE
Implement variable width and precision (i.e. %*.*f).

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ follow the decimal point in the `%f`, `%e`, and `%E` conversions.  For instance,
 The integer in a width or precision can also be specified as "\*", in which case
 an extra number argument is taken to specify the corresponding width or precision.
 This integer argument precedes immediately the argument to print.  For instance,
-%\*d prints a number with as many digits as the value of the argument given before the number.
+%.\*f prints a number with as many cractional digits as the value of the argument
+given before the number.
 
 Pretty-printing indications are `@` followed by one ore more characters.
 Their meanings are:

--- a/README.md
+++ b/README.md
@@ -382,7 +382,6 @@ Incompatiblity with OCaml
 
 Unsupported features (currently, at least) are:
 
- * `*` for "width" and "precision" in conversion specifications. (i.e. `%*.*d`)
  * Semantic tags. (i.e. `open_tag ()` and related functions)
  * `@<n>`, a pritty-printing indication.
  * Tabulation. (i.e. `open_tbox ()` and related functions)

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ NOTE that currently cyclic object is not supported.  They may cause infinite loo
 
 Can be obtained by `Format.Formatter`.
 Most of the description for the class is largely based on the the document of
-OCaml's Format module.
+OCaml's Format module and Printf module.
 
 ##### new Formatter(options)
 
@@ -220,6 +220,10 @@ The optional `precision` is an integer following to a dot ".", indicating how ma
 follow the decimal point in the `%f`, `%e`, and `%E` conversions.  For instance,
 `%.4f` prints a float with 4 fractional digits.
 
+The integer in a width or precision can also be specified as "\*", in which case
+an extra number argument is taken to specify the corresponding width or precision.
+This integer argument precedes immediately the argument to print.  For instance,
+%\*d prints a number with as many digits as the value of the argument given before the number.
 
 Pretty-printing indications are `@` followed by one ore more characters.
 Their meanings are:

--- a/lib/Formatter.js
+++ b/lib/Formatter.js
@@ -259,7 +259,7 @@ proto.printf_a_ = function (format, args) {
   }
 
   var matched;
-  var re = /(?:(@.|@\n)|(?:%([-0+ #]*)([1-9]\d*)?(?:.([1-9]\d*))?(.)))([^@%]*)/g;
+  var re = /(?:(@.|@\n)|(?:%([-0+ #]*)([\*]|[1-9]\d*)?(?:.([\*]|[1-9]\d*))?(.)))([^@%]*)/g;
   re.lastIndex = s.length;
 
   while (matched = re.exec(format)) {
@@ -269,9 +269,6 @@ proto.printf_a_ = function (format, args) {
     var perPrec = matched[4];
     var perType = matched[5];
     var trailing = matched[6];
-
-    perWidth = perWidth && Number(perWidth);
-    perPrec = perPrec && Number(perPrec);
 
     if (atX) {
       // we found "@": atX and trailing are not undefined
@@ -336,6 +333,11 @@ proto.printf_a_ = function (format, args) {
       }
     } else if (perType) {
       // we found "%"
+      if (perWidth)
+        perWidth = (perWidth !== "*") ? Number(perWidth) : nextArg("number");
+      if (perPrec)
+        perPrec = (perPrec !== "*") ? Number(perPrec) : nextArg("number");
+
       switch (perType) {
       case "d": case "i":
       case "x": case "X": case "o":

--- a/test/general.spec.js
+++ b/test/general.spec.js
@@ -112,4 +112,14 @@ describe("general", function () {
     expect(pp.sprintf("AA%-10BZZ", false)).to.equal("AAfalseZZ");
     expect(pp.sprintf("AA%10tZZ", function (ppf) { ppf.printf("s") })).to.equal("AAsZZ");
   });
+
+  it("%*.*f", function () {
+    expect(pp.sprintf("AA%*sBB", 10, "foo")).to.equal("AA       fooBB");
+    expect(pp.sprintf("AA%-*dBB", 10, 30)).to.equal("AA30        BB");
+    expect(pp.sprintf("AA%.*fBB", 2, 42.12345)).to.equal("AA42.12BB");
+    expect(pp.sprintf("AA%+10.*fBB", 2, 42.12345)).to.equal("AA    +42.12BB");
+    expect(pp.sprintf("AA%+*.*fBB", 8, 2, 42.12345)).to.equal("AA  +42.12BB");
+    expect(pp.sprintf("AA% .*fBB", 3, 42.12345)).to.equal("AA 42.123BB");
+  });
+
 });


### PR DESCRIPTION
- Implement printf()'s variable minimum-width and precision specification (i.e. `%*.*f`)
- Update README.md
- Add tests.
