### PR TITLE
Fix setMaxIndent() to accept zero

### DIFF
--- a/lib/Format.js
+++ b/lib/Format.js
@@ -34,6 +34,7 @@ function strFormatterFun(n) {
 
 var Format = {
   Formatter: Formatter,
+  DEFAULT_MARGIN: DEFAULT_MARGIN,
 
   stdFormatter: new Formatter({
     margin: DEFAULT_MARGIN,

--- a/lib/Formatter.js
+++ b/lib/Formatter.js
@@ -16,14 +16,21 @@ function Formatter(opt) {
   opt || (opt = {});
 
   this.printer_ = new Printer(opt);
-  this.margin_ = opt.margin || 80;
-  this.maxIndent_ = opt.maxIndent || 0;
-  this.maxBoxes_ = opt.maxBoxes || 0;
-  this.ellipsisText_ = opt.ellipsisText || ".";
+  this.margin_ = 80;
+  this.maxIndent_ = 0;
+  this.maxBoxes_ = 0;
+  this.ellipsisText_ = ".";
   this.boxes_ = [];
   this.rootBox_ = new Hbox(this);
 
   this.nestCount_ = 0;
+
+  if (opt.margin != null)
+    this.setMargin(opt.margin, opt.maxIndent);
+  if (opt.maxBoxes != null)
+    this.setMaxBoxes(opt.maxBoxes);
+  if (opt.ellipsisText != null)
+    this.setEllipsisText(opt.ellipsisText);
 }
 
 Formatter.MAX_MARGIN = 1e9;
@@ -122,9 +129,9 @@ proto.printIfNewline = function () {
 };
 
 proto.setMargin = function (margin, maxIndent) {
-  if (margin && margin >= 2)
+  if (margin >= 2)
     this.margin_ = Math.min(margin, Formatter.MAX_MARGIN);
-  if (maxIndent)
+  if (maxIndent != null)
     this.setMaxIndent(maxIndent);
 };
 
@@ -133,10 +140,8 @@ proto.getMargin = function () {
 };
 
 proto.setMaxIndent = function (maxIndent) {
-  if (maxIndent && maxIndent >= 2)
+  if (maxIndent === 0 || maxIndent >= 2)
     this.maxIndent_ = Math.min(maxIndent, Formatter.MAX_MAX_INDENT);
-  if (this.margin_)
-    this.maxIndent_ = Math.min(this.maxIndent_, this.margin_);
 };
 
 proto.getMaxIndent = function () {

--- a/test/general.spec.js
+++ b/test/general.spec.js
@@ -5,7 +5,26 @@ var pp = require("../");
 
 describe("general", function () {
 
+  var savedStatus;
+
+  beforeEach(function () {
+    savedStatus = {
+      mgn: pp.getMargin(),
+      mi: pp.getMaxIndent(),
+      smgn: pp.getStrMargin(),
+      smi: pp.getStrMaxIndent()
+    };
+  });
+
+  afterEach(function () {
+    pp.setMargin(savedStatus.mgn, savedStatus.mi);
+    pp.setStrMargin(savedStatus.smgn, savedStatus.smi);
+  });
+
   it("margin/maxIndent", function () {
+    expect(pp.getMargin()).to.equal(pp.DEFAULT_MARGIN);
+    expect(pp.getMaxIndent()).to.equal(0);
+
     pp.setMargin(40);
     expect(pp.getMargin()).to.equal(40);
 
@@ -18,6 +37,9 @@ describe("general", function () {
   });
 
   it("strMargin/strMaxIndent", function () {
+    expect(pp.getStrMargin()).to.equal(pp.DEFAULT_MARGIN);
+    expect(pp.getStrMaxIndent()).to.equal(0);
+
     pp.setStrMargin(40);
     expect(pp.getStrMargin()).to.equal(40);
 
@@ -90,15 +112,19 @@ describe("general", function () {
   });
 
   it("treats break hints", function () {
-    var mgn = pp.getStrMargin(), mi = pp.getStrMaxIndent();
-    try {
-      pp.setStrMargin(20, 19);
-      var s = pp.sprintf("@[foo@;bar@]@?");
-      var a = "foo bar";
-      expect(s).to.equal(a);
-    } finally {
-      pp.setStrMargin(mgn, mi);
-    }
+    pp.setStrMargin(20, 19);
+    var s = pp.sprintf("@[foo@;bar@]@?");
+    var a = "foo bar";
+    expect(s).to.equal(a);
+  });
+
+  it("bleeds out the margin unless breakable", function () {
+    pp.setStrMargin(8);
+    var s = pp.sprintf("@[<hov 4><123456789@ @[<hov 4><123456789@ @[<hov 4><123456789>@]>@]>@]");
+    var a = "<123456789\n"
+          + "    <123456789\n"
+          + "        <123456789>>>";
+    expect(s).to.equal(a);
   });
 
   it("regression: can be specieid width for %s", function () {


### PR DESCRIPTION
Fixed Formatter#setMaxIndent() to accept zero.  This is the default value which mean that the indentation is not limited.  Before this commit we could not reset the max indent value to the default one.

Also fixed tests to reset margins and max indent values for each tests.