### PR TITLE
Fix hvbox margin

### DIFF
--- a/lib/Hvbox.js
+++ b/lib/Hvbox.js
@@ -16,7 +16,7 @@ var Hvbox = (function () {
 
   proto.print_ = function (boxLeft, startColumn) {
     var limit = this.formatter_.margin() - 1;
-    if ((this.leftPosAfterPutHorizontally(startColumn, limit) >= limit) ||
+    if ((this.leftPosAfterPutHorizontally(startColumn, limit) > limit) ||
         (this.sensitive_ && this.hasHardBreakHint())) {
       this.hints_.forEach(function (h) { h.setToBreak(true); });
     }

--- a/test-src/dataset-compat.json
+++ b/test-src/dataset-compat.json
@@ -94,5 +94,10 @@
     "comment": "force newline",
     "margin": [6, 10, 20],
     "source": "@[foo@ @[[aaaa@\nbbb@ cccc]@]@ zzz@]@."
+  },
+  {
+    "comment": "issue at v0.1.3: hvbox margin handling mistake",
+    "margin": [3, 5, 7, 9],
+    "source": "@[<hv>[@;<0 2>@[<hov>3,@ 1@]@,]@]@."
   }
 ]

--- a/test/autogen-compat.spec.js
+++ b/test/autogen-compat.spec.js
@@ -1370,5 +1370,67 @@ describe("compatibility", function () {
     expect(formatted).equal(expected);
   });
 
+  it("3/\"@[<hv>[@;<0 2>@[<hov>3,@ 1@]@,]@]@.\"", function () {
+    // issue at v0.1.3: hvbox margin handling mistake
+    /* 
+      123
+      [
+        3,
+        1
+      ]
+      
+     */
+    var ppf = new pp.Formatter();
+    ppf.setMargin(3, 2);
+    var formatted = ppf.printf("@[<hv>[@;<0 2>@[<hov>3,@ 1@]@,]@]@.");
+    var expected = "[\n  3,\n  1\n]\n";
+    expect(formatted).equal(expected);
+  });
+
+  it("5/\"@[<hv>[@;<0 2>@[<hov>3,@ 1@]@,]@]@.\"", function () {
+    // issue at v0.1.3: hvbox margin handling mistake
+    /* 
+      12345
+      [
+        3,
+        1
+      ]
+      
+     */
+    var ppf = new pp.Formatter();
+    ppf.setMargin(5, 4);
+    var formatted = ppf.printf("@[<hv>[@;<0 2>@[<hov>3,@ 1@]@,]@]@.");
+    var expected = "[\n  3,\n  1\n]\n";
+    expect(formatted).equal(expected);
+  });
+
+  it("7/\"@[<hv>[@;<0 2>@[<hov>3,@ 1@]@,]@]@.\"", function () {
+    // issue at v0.1.3: hvbox margin handling mistake
+    /* 
+      1234567
+      [3, 1]
+      
+     */
+    var ppf = new pp.Formatter();
+    ppf.setMargin(7, 6);
+    var formatted = ppf.printf("@[<hv>[@;<0 2>@[<hov>3,@ 1@]@,]@]@.");
+    var expected = "[3, 1]\n";
+    expect(formatted).equal(expected);
+  });
+
+  it("9/\"@[<hv>[@;<0 2>@[<hov>3,@ 1@]@,]@]@.\"", function () {
+    // issue at v0.1.3: hvbox margin handling mistake
+    /* 
+      123456789
+      [3, 1]
+      
+     */
+    var ppf = new pp.Formatter();
+    ppf.setMargin(9, 8);
+    var formatted = ppf.printf("@[<hv>[@;<0 2>@[<hov>3,@ 1@]@,]@]@.");
+    var expected = "[3, 1]\n";
+    expect(formatted).equal(expected);
+  });
+
 });
 


### PR DESCRIPTION
Fix an incompatibility with OCaml caused by a simple mistake : Other `Box#leftPosAfterPutHorizontally()` is compared by `>` but not `>=`.
